### PR TITLE
Hijacked the "backup_name_mode" setting to carry the backup file name format

### DIFF
--- a/autobackups/paths_helper.py
+++ b/autobackups/paths_helper.py
@@ -69,23 +69,17 @@ class PathsHelper(object):
     def create_name_file(filename):
         (filepart, extensionpart) = os.path.splitext(filename)
 
-        if PathsHelper.backup_name_mode not in (False, None, ) \
-          and PathsHelper.backup_name_mode.lower() == 'prefix':
-            filepart = '%s.%s' % (backup_name_mode_text, filepart)
+        now_date = str(datetime.datetime.now())
+        date = now_date[:10]
+        time = now_date[11:19].replace(':', '')
 
-        backup_per_day =  PathsHelper.backup_per_day
-        backup_per_time =  PathsHelper.backup_per_time
-        if (backup_per_day and backup_per_time == 'file'):
-            now_date = str(datetime.datetime.now())
-            time = now_date[11:19].replace(':', '')
-            name = '%s_%s%s' % (filepart, time, extensionpart,)
-        else:
-            name = '%s%s' % (filepart, extensionpart,)
+        name_format = re.sub('[^0-9a-zA-Z._-]', '', PathsHelper.backup_name_mode)
+        name = name_format.replace('name', filepart)
+        name = name.replace('date', date)
+        name = name.replace('time', time)
+        name = name.replace('tag', backup_name_mode_text)
+        name = name.replace('ext', extensionpart.strip('.'))
 
-        (filepart, extensionpart) = os.path.splitext(name) 
-        if PathsHelper.backup_name_mode not in (False, None, ) \
-          and PathsHelper.backup_name_mode.lower() == 'suffix':
-            name = '%s.%s%s' % (filepart, backup_name_mode_text, extensionpart)
         return name
 
     @staticmethod


### PR DESCRIPTION
The option can now contain a string built with the following blocks:
1. 'tag'
2. 'name'
3. 'date'
4. 'time'
5. 'ext'
or the following characters:
1. "-" (minus)
2. "_" (underscore)
3. "." (dot)
Examples: "name.ext", "name.tag.ext", "name_date-time.ext", "tag_date-time.name.ext".

Changed the create_name_file function to ignore the "backup_per_day" and "backup_per_time" settings - you can have date and/or time both as folders or in the file name if you so fancy. The "backup_per_day" and "backup_per_time" settings could be seen rather as "folder_per_day" and "folder_per_second".